### PR TITLE
Fixed jim list and readme to use latest convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ func Users(ctx context.Context, args []string) error {
 To run the above mentioned task we can use the `jim` command:
 
 ```bash
-$ jim db/seed:Users 1 2 3 4
+$ jim db/seed.Users 1 2 3 4
 
 loading users [1 2 3 4]
 ```
 
-Let's break down the `db/seed:Users` bit, shall we? The last part, `Users` is the name of the function that will be run. This **MUST** match capitalization.
+Let's break down the `db/seed.Users` bit, shall we? The last part, `Users` is the name of the function that will be run. This **MUST** match capitalization.
 
 The `db/seed` part is converted to the package `<module path>/db/seed` which, hopefully, contains a `Users` function that matches the correct API.
 
@@ -93,7 +93,7 @@ To run your task via the API in your application, give it a `context.Context`, s
 The `jim -h` flag, followed by the task will print the GoDoc for that function.
 
 ```bash
-$ jim -h db/seed:Users
+$ jim -h db/seed.Users
 
 package seed // import "ref/db/seed"
 
@@ -106,8 +106,8 @@ func Users(ctx context.Context, args []string) error
 ```bash
 $ jim list
 
-ref/db/seed:Users
-ref/db:Seed
-ref/task:Another
-ref/task:Something
+ref/db/seed.Users
+ref/db.Seed
+ref/task.Another
+ref/task.Something
 ```

--- a/list_test.go
+++ b/list_test.go
@@ -26,10 +26,10 @@ func Test_List(t *testing.T) {
 	}
 
 	exp := []string{
-		"ref/db/seed:Users",
-		"ref/db:Seed",
-		"ref/task:Another",
-		"ref/task:Something",
+		"ref/db.Seed",
+		"ref/db/seed.Users",
+		"ref/task.Another",
+		"ref/task.Something",
 	}
 	r.Equal(exp, act)
 }

--- a/task.go
+++ b/task.go
@@ -21,7 +21,7 @@ type Task struct {
 }
 
 func (t Task) String() string {
-	return fmt.Sprintf("%s:%s", t.Pkg, t.Name)
+	return fmt.Sprintf("%s.%s", t.Pkg, t.Name)
 }
 
 func New(args []string) (*Task, error) {


### PR DESCRIPTION
Fixed the jim  list command that was displaying the tasks
It was using path:Task instread of path.Task

Fixed also the readme about it.